### PR TITLE
Fix packages that live in a subdir

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -13,7 +13,8 @@
   },
   {
     "package": "DSsim",
-    "url": "https://github.com/distanceDevelopment/DSsim/"
+    "url": "https://github.com/distanceDevelopment/DSsim/",
+    "subdir": "DSsim"
   },
   {
     "package": "dssd",
@@ -25,7 +26,8 @@
   },
   {
     "package": "mads",
-    "url": "https://github.com/distanceDevelopment/mads/"
+    "url": "https://github.com/distanceDevelopment/mads/",
+    "subdir" : "mads"
   },
   {
     "package": "readdst",


### PR DESCRIPTION
If the package DESCRIPTION does not live in the root of the repository, you need to specify the `subdir`